### PR TITLE
Add a limit to the replay buffer size which can be specified in the args. Also allow for the seed to be specified in the args when running the script 3 for testing.

### DIFF
--- a/duckietown_rl/args.py
+++ b/duckietown_rl/args.py
@@ -1,7 +1,7 @@
 import argparse
 
 
-def get_ddpg_args():
+def get_ddpg_args_train():
     parser = argparse.ArgumentParser()
     parser.add_argument("--seed", default=0, type=int)  # Sets Gym, PyTorch and Numpy seeds
     parser.add_argument("--start_timesteps", default=1e4, type=int)  # How many time steps purely random policy is run for
@@ -16,4 +16,14 @@ def get_ddpg_args():
     parser.add_argument("--noise_clip", default=0.5, type=float)  # Range to clip target policy noise
     parser.add_argument("--policy_freq", default=2, type=int)  # Frequency of delayed policy updates
     parser.add_argument("--env_timesteps", default=500, type=int)  # Frequency of delayed policy updates
+    parser.add_argument("--replay_buffer_max_size", default=1000, type=int)  # Maximum number of steps to keep in the replay buffer
+
+    return parser.parse_args()
+
+
+def get_ddpg_args_test():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--seed", default=0, type=int)  # Sets Gym, PyTorch and Numpy seeds
+    parser.add_argument("--experiment", default=2, type=int)
+    
     return parser.parse_args()

--- a/duckietown_rl/args.py
+++ b/duckietown_rl/args.py
@@ -16,7 +16,7 @@ def get_ddpg_args_train():
     parser.add_argument("--noise_clip", default=0.5, type=float)  # Range to clip target policy noise
     parser.add_argument("--policy_freq", default=2, type=int)  # Frequency of delayed policy updates
     parser.add_argument("--env_timesteps", default=500, type=int)  # Frequency of delayed policy updates
-    parser.add_argument("--replay_buffer_max_size", default=1000, type=int)  # Maximum number of steps to keep in the replay buffer
+    parser.add_argument("--replay_buffer_max_size", default=10000, type=int)  # Maximum number of steps to keep in the replay buffer
 
     return parser.parse_args()
 

--- a/duckietown_rl/utils.py
+++ b/duckietown_rl/utils.py
@@ -22,11 +22,10 @@ class ReplayBuffer(object):
 
     # Expects tuples of (state, next_state, action, reward, done)
     def add(self, state, next_state, action, reward, done):
-        #print(len(self.storage))
         if len(self.storage) < self.max_size:
             self.storage.append((state, next_state, action, reward, done))
         else:
-            # Remove random elements
+            # Remove random element in the memory beforea adding a new one
             self.storage.pop(random.randrange(len(self.storage)))
             self.storage.append((state, next_state, action, reward, done))
 

--- a/duckietown_rl/utils.py
+++ b/duckietown_rl/utils.py
@@ -16,12 +16,20 @@ def seed(seed):
 
 # Simple replay buffer
 class ReplayBuffer(object):
-    def __init__(self):
+    def __init__(self,max_size):
         self.storage = []
+        self.max_size = max_size
 
     # Expects tuples of (state, next_state, action, reward, done)
     def add(self, state, next_state, action, reward, done):
-        self.storage.append((state, next_state, action, reward, done))
+        print(len(self.storage))
+        if len(self.storage < self.max_size):
+            self.storage.append((state, next_state, action, reward, done))
+        else:
+            # Remove random elements
+            self.storage.pop(random.randrange(len(x)))
+            self.storage.append((state, next_state, action, reward, done))
+
 
     def sample(self, batch_size=100, flat=True):
         ind = np.random.randint(0, len(self.storage), size=batch_size)

--- a/duckietown_rl/utils.py
+++ b/duckietown_rl/utils.py
@@ -22,12 +22,12 @@ class ReplayBuffer(object):
 
     # Expects tuples of (state, next_state, action, reward, done)
     def add(self, state, next_state, action, reward, done):
-        print(len(self.storage))
-        if len(self.storage < self.max_size):
+        #print(len(self.storage))
+        if len(self.storage) < self.max_size:
             self.storage.append((state, next_state, action, reward, done))
         else:
             # Remove random elements
-            self.storage.pop(random.randrange(len(x)))
+            self.storage.pop(random.randrange(len(self.storage)))
             self.storage.append((state, next_state, action, reward, done))
 
 

--- a/scripts/2-train-ddpg-cnn.py
+++ b/scripts/2-train-ddpg-cnn.py
@@ -55,7 +55,7 @@ max_action = float(env.action_space.high[0])
 # Initialize policy
 policy = DDPG(state_dim, action_dim, max_action, net_type="cnn")
 
-replay_buffer = utils.ReplayBuffer()
+replay_buffer = utils.ReplayBuffer(args.replay_buffer_max_size)
 
 # Evaluate untrained policy
 evaluations= [evaluate_policy(env, policy)]

--- a/scripts/2-train-ddpg-cnn.py
+++ b/scripts/2-train-ddpg-cnn.py
@@ -9,7 +9,7 @@ import os
 from hyperdash import Experiment
 
 from duckietown_rl import utils
-from duckietown_rl.args import get_ddpg_args
+from duckietown_rl.args import get_ddpg_args_train
 from duckietown_rl.ddpg import DDPG
 from duckietown_rl.utils import seed, evaluate_policy
 from duckietown_rl.wrappers import NormalizeWrapper, ImgWrapper, \
@@ -21,7 +21,7 @@ exp = Experiment("[duckietown] - ddpg")
 
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-args = get_ddpg_args()
+args = get_ddpg_args_train()
 
 file_name = "{}_{}_{}".format(
     policy_name,

--- a/scripts/3-test-ddpg-cnn.py
+++ b/scripts/3-test-ddpg-cnn.py
@@ -3,12 +3,15 @@ import gym_duckietown
 import torch
 from duckietown_rl.ddpg import DDPG
 from duckietown_rl.utils import evaluate_policy
+from duckietown_rl.args import get_ddpg_args_test
 from duckietown_rl.wrappers import NormalizeWrapper, ImgWrapper, \
     DtRewardWrapper, ActionWrapper, ResizeWrapper
 import numpy as np
 
-experiment = 2
-seed = 1
+args = get_ddpg_args_test()
+
+experiment = args.experiment
+seed = args.seed
 policy_name = "DDPG"
 
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -21,7 +24,6 @@ file_name = "{}_{}_{}".format(
 )
 
 env = gym.make("Duckietown-loop_obstacles-v0")
-
 
 # Wrappers
 env = ResizeWrapper(env)


### PR DESCRIPTION
I was having memory issues when running the script 2 for training. After a while, the memory on my computer would be full because of the replay buffer which kept increasing in size. 
I limited the size by randomly removing one element when we add a new one and it has already reached the specified max size (10000 by default).